### PR TITLE
apply styles to tableborders and toggle props

### DIFF
--- a/xpl/docx2hub.xpl
+++ b/xpl/docx2hub.xpl
@@ -248,6 +248,48 @@
     </p:input>
   </docx2hub:single-tree-enhanced>
   
+  <tr:xslt-mode msg="yes" mode="docx2hub:preprocess-styles" name="preprocess-styles">
+    <p:input port="parameters">
+      <p:pipe step="single-tree-enhanced" port="params"/>
+    </p:input>
+    <p:input port="stylesheet">
+      <p:pipe step="docx2hub" port="xslt"/>
+    </p:input>
+    <p:input port="models">
+      <p:empty/>
+    </p:input>
+    <p:with-option name="prefix" select="concat('docx2hub/', /c:param-set/c:param[@name='basename']/@value, '/03a')">
+      <p:pipe port="params" step="single-tree-enhanced"/> 
+    </p:with-option>
+    <p:with-option name="debug" select="$debug"/>
+    <p:with-option name="debug-dir-uri" select="$debug-dir-uri"/>
+    <p:with-option name="fail-on-error" select="$fail-on-error"/>
+    <p:with-param name="fail-on-error" select="$fail-on-error"/>
+    <p:with-param name="field-vars" select="$field-vars"/>
+    <p:with-param name="mathtype2mml" select="$mathtype2mml"/>
+  </tr:xslt-mode>
+  
+  <tr:xslt-mode msg="yes" mode="docx2hub:resolve-tblBorders" name="resolve-tblBorders">
+    <p:input port="parameters">
+      <p:pipe step="single-tree-enhanced" port="params"/>
+    </p:input>
+    <p:input port="stylesheet">
+      <p:pipe step="docx2hub" port="xslt"/>
+    </p:input>
+    <p:input port="models">
+      <p:empty/>
+    </p:input>
+    <p:with-option name="prefix" select="concat('docx2hub/', /c:param-set/c:param[@name='basename']/@value, '/03b')">
+      <p:pipe port="params" step="single-tree-enhanced"/> 
+    </p:with-option>
+    <p:with-option name="debug" select="$debug"/>
+    <p:with-option name="debug-dir-uri" select="$debug-dir-uri"/>
+    <p:with-option name="fail-on-error" select="$fail-on-error"/>
+    <p:with-param name="fail-on-error" select="$fail-on-error"/>
+    <p:with-param name="field-vars" select="$field-vars"/>
+    <p:with-param name="mathtype2mml" select="$mathtype2mml"/>
+  </tr:xslt-mode>
+  
   <tr:xslt-mode msg="yes" mode="docx2hub:add-props" name="add-props">
     <p:input port="parameters">
       <p:pipe step="single-tree-enhanced" port="params"/>
@@ -258,7 +300,7 @@
     <p:input port="models">
       <p:empty/>
     </p:input>
-    <p:with-option name="prefix" select="concat('docx2hub/', /c:param-set/c:param[@name='basename']/@value, '/03')">
+    <p:with-option name="prefix" select="concat('docx2hub/', /c:param-set/c:param[@name='basename']/@value, '/04')">
       <p:pipe port="params" step="single-tree-enhanced"/> 
     </p:with-option>
     <p:with-option name="debug" select="$debug"/>

--- a/xsl/main.xsl
+++ b/xsl/main.xsl
@@ -29,12 +29,13 @@
   <xsl:import href="wml2dbk.xsl"/>
   <xsl:import href="insert-xpath.xsl"/>
   <xsl:import href="modules/prop-mapping/map-props.xsl"/>
+  <xsl:import href="modules/preprocess-styles/preprocess-styles.xsl"/>
   <xsl:import href="join-runs.xsl"/>
   
   <xsl:import href="http://transpect.io/xslt-util/xslt-based-catalog-resolver/xsl/resolve-uri-by-catalog.xsl"/>
   <xsl:param name="cat:missing-next-catalogs-warning" as="xs:string" select="'no'"/>
   <xsl:variable name="catalog" as="document-node(element(cat:catalog))?" select="collection()[cat:catalog]"/>
-
+  
   <!-- ================================================================================ -->
   <!-- OUTPUT FORMAT -->
   <!-- ================================================================================ -->

--- a/xsl/modules/preprocess-styles/preprocess-styles.xsl
+++ b/xsl/modules/preprocess-styles/preprocess-styles.xsl
@@ -1,0 +1,298 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+  xmlns:docx2hub="http://transpect.io/docx2hub"
+  exclude-result-prefixes="xsl xs docx2hub"
+  version="2.0">
+  
+  <xsl:variable name="word-2013-tablestyle-rules" select="
+    every $b in (//w:settings/w:compat//(
+      (xs:decimal(w:compatSetting[@w:name = 'compatibilityMode']/@w:val), 15)[1] lt 15
+      and
+      not(w:compatSetting[@w:name = 'differentiateMultirowTableHeaders'][@w:val = (1, 'true')])
+    )) satisfies not($b)" as="xs:boolean"/>
+  
+  <xsl:template match="w:styles/w:style[@w:type = 'table']" exclude-result-prefixes="#all" mode="docx2hub:preprocess-styles">
+    <!-- (w:style)* -->
+    <xsl:variable name="self" select="."/>
+    <xsl:variable name="doc-styles" select=".."/>
+    <xsl:for-each select="('', w:tblStylePr/@w:type)">
+      <xsl:variable name="stripped-style" as="node()">
+        <w:style>
+          <xsl:sequence select="$self/@* except $self/@w:styleId"/>
+          <xsl:attribute name="w:styleId" select="($self[current() = '']/@w:styleId, concat($self/@w:styleId, '-', .))[1]"/>
+          <xsl:variable name="bare-props" select="$self/node()[not(self::w:tblStylePr)]" as="node()*"/>
+          <xsl:sequence
+            select="docx2hub:consolidate-style-properties($self/element()[self::w:tblStylePr[@w:type = current()]]/element(), $bare-props)"
+          />
+        </w:style>
+      </xsl:variable>
+      <xsl:element name="{$self/name()}">
+        <xsl:sequence
+          select="$stripped-style/@*, docx2hub:get-style-properties($stripped-style, $doc-styles)"
+        />
+      </xsl:element>
+    </xsl:for-each>
+  </xsl:template>
+  
+  <xsl:template match="w:tc[empty(w:tcPr)]" exclude-result-prefixes="#all" mode="docx2hub:preprocess-styles">
+    <xsl:copy>
+      <xsl:apply-templates select="@*" mode="#current"/>
+      <xsl:element name="w:tcPr"/>
+      <xsl:apply-templates select="node()"/>
+    </xsl:copy>
+  </xsl:template>
+  
+  <xsl:function name="docx2hub:get-style-properties" as="node()*">
+    <xsl:param name="style" as="node()"/><!-- w:style -->
+    <xsl:param name="styles" as="node()*"/><!-- (w:style)* -->
+    <xsl:variable name="based-on" select="$style/w:basedOn/@w:val"/>
+    <xsl:variable name="resolved-parent-style"
+      select="if (exists($styles/node()[@w:styleId = $based-on]))
+        then docx2hub:get-style-properties($styles/node()[@w:styleId = $based-on], $styles)
+        else ()"
+      as="node()*"/>
+    <xsl:sequence select="docx2hub:consolidate-style-properties($style/element(), $resolved-parent-style)"/>
+  </xsl:function>
+
+  <xsl:function name="docx2hub:consolidate-style-properties" as="node()*">
+    <xsl:param name="style1" as="node()*"/>
+    <xsl:param name="style2" as="node()*"/>
+    <xsl:for-each select="$style1">
+      <xsl:variable name="ptype" select="concat(local-name(), @w:type)"/>
+      <xsl:choose>
+        <xsl:when test="self::w:tblBorders and not($word-2013-tablestyle-rules)">
+          <xsl:sequence select="."/>
+        </xsl:when>
+        <xsl:when test="not(node()) and @*">
+          <!-- copy flat prop from style1 -->
+          <xsl:element name="{name()}">
+            <xsl:sequence select="$style2[concat(local-name(), @w:type) = $ptype]/@*, @*"/>
+          </xsl:element>
+        </xsl:when>
+        <xsl:otherwise>
+          <!-- recursive for nested props -->
+          <xsl:element name="{name()}">
+            <xsl:sequence select="@*"/>
+            <xsl:sequence
+              select="docx2hub:consolidate-style-properties(element(), $style2[concat(local-name(), @w:type) = $ptype]/element())"
+            />
+          </xsl:element>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+    <xsl:for-each select="$style2">
+      <xsl:variable name="ptype" as="xs:string"
+        select="concat('', local-name(), @w:type[count($style1/element()[local-name() = current()/local-name()]) gt 1])"/>
+      <xsl:choose>
+        <xsl:when test="$style1[concat('', local-name(), @w:type[count($style1/element()[local-name() = current()/local-name()]) gt 1]) = $ptype]">
+          <!-- this one was copied from style1 already -->
+        </xsl:when>
+        <xsl:otherwise>
+          <!-- props added by style2 -->
+          <xsl:sequence select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+
+  <xsl:template match="w:tbl/w:tr" mode="docx2hub:resolve-tblBorders">
+    <xsl:next-match>
+      <xsl:with-param name="tr-pos"
+        select="count(preceding-sibling::*) + 1 - count(preceding-sibling::*[not(self::w:tr)])" tunnel="yes"/>
+    </xsl:next-match>
+  </xsl:template>
+  
+  <xsl:template match="w:tbl/w:tr/w:tc" mode="docx2hub:resolve-tblBorders">
+    <xsl:param name="tr-pos" tunnel="yes"/>
+    <xsl:variable name="self" select="."/>
+    <xsl:variable name="tc-pos" select="count(preceding-sibling::*) + 1 - count(preceding-sibling::*[not(self::w:tc)])"/>
+    <xsl:variable name="pos" select="$tc-pos, $tr-pos, ../count(w:tc), ../../count(w:tr)" as="xs:decimal+">
+      <!-- values are: tc-pos, tr-pos, last-tc, last-tr -->
+    </xsl:variable>
+    <xsl:variable name="style-name" as="xs:string*">
+      <xsl:variable name="prefix" select="../../w:tblPr/w:tblStyle/@w:val"/>
+      <xsl:variable name="lk" as="xs:boolean+"
+      select="
+      ((../../w:tblPr/w:tblLook, ../w:tblPrEx/w:tblBorders)/@w:firstRow)[1] = (1, 'true'),
+      ((../../w:tblPr/w:tblLook, ../w:tblPrEx/w:tblBorders)/@w:firstColumn)[1] = (1, 'true'),
+      ((../../w:tblPr/w:tblLook, ../w:tblPrEx/w:tblBorders)/@w:lastRow)[1] = (1, 'true'),
+      ((../../w:tblPr/w:tblLook, ../w:tblPrEx/w:tblBorders)/@w:lastColumn)[1] = (1, 'true')"/>
+      <xsl:variable name="suffix" as="xs:string*">
+        <xsl:variable name="possible-suffixes" as="xs:string*">
+          <xsl:choose>
+            <xsl:when test="$lk[2] and $lk[1] and $pos[1] eq 1 and $pos[2] eq 1">
+              <xsl:sequence select="'nwCell', 'firstRow', 'firstCol'"/>
+            </xsl:when>
+            <xsl:when test="$lk[2] and $lk[3] and $pos[1] eq 1 and $pos[2] eq $pos[4]">
+              <xsl:sequence select="'swCell', 'lastRow', 'firstCol'"/>
+            </xsl:when>
+            <xsl:when test="$lk[4] and $lk[1] and $pos[1] eq $pos[3] and $pos[2] eq 1">
+              <xsl:sequence select="'neCell', 'firstRow', 'lastCol'"/>
+            </xsl:when>
+            <xsl:when test="$lk[4] and $lk[3] and $pos[1] eq $pos[3] and $pos[2] eq $pos[4]">
+              <xsl:sequence select="'seCell', 'lastRow', 'lastCol'"/>
+            </xsl:when>
+            <xsl:when test="$lk[2] and $pos[1] eq 1">
+              <xsl:sequence select="'firstCol'"/>
+            </xsl:when>
+            <xsl:when test="$lk[1] and $pos[2] eq 1">
+              <xsl:sequence select="'firstRow'"/>
+            </xsl:when>
+            <xsl:when test="$lk[3] and $pos[1] eq $pos[3]">
+              <xsl:sequence select="'lastRow'"/>
+            </xsl:when>
+            <xsl:when test="$lk[4] and $pos[2] eq $pos[4]">
+              <xsl:sequence select="'lastCol'"/>
+            </xsl:when>
+            <!-- TODO: H/V-banding props -->
+            <xsl:otherwise/>
+          </xsl:choose>
+        </xsl:variable>
+        <xsl:sequence select="for $s in $possible-suffixes return $s[exists($self/ancestor::*[last()]//w:style[@w:styleId = concat($prefix, '-', $s)])]"/>
+      </xsl:variable>
+      <xsl:sequence select="$prefix[empty($suffix)] ,for $s in $suffix return string-join(($prefix, ('-', $s)[not($s= '')]), '')"/>
+    </xsl:variable>
+    <xsl:variable name="sty" select="for $s in $style-name return $self/ancestor::*[last()]//w:style[@w:styleId = concat('', $s)]" as="element()*"/>
+    <xsl:next-match>
+      <xsl:with-param name="tc-pos" select="$tc-pos" tunnel="yes"/>
+      <xsl:with-param name="tblsty" select="$sty" tunnel="yes"/>
+    </xsl:next-match>
+  </xsl:template>
+
+  <xsl:template mode="docx2hub:resolve-tblBorders"
+    match="w:tbl/w:tr/w:tc/w:tcPr[empty(ancestor::*/(w:tblPrEx|w:tblPr)/w:tblCellSpacing[matches(@w:w, '[1-9]')])]">
+    <xsl:param name="tr-pos" tunnel="yes"/>
+    <xsl:param name="tc-pos" tunnel="yes"/>
+    <xsl:param name="tblsty" tunnel="yes" as="element()*"/>
+    <xsl:variable name="self" select="."/>
+    <xsl:variable name="pos" select="$tc-pos, $tr-pos, count(../../w:tc), ../../../count(w:tr)" as="xs:decimal+">
+      <!-- values are: tc-pos, tr-pos, last-tc, last-tr -->
+    </xsl:variable>
+    <xsl:copy copy-namespaces="no">
+      <xsl:apply-templates select="@*" mode="#current"/>
+      <xsl:apply-templates select="node() except w:tcBorders" mode="#current"/>
+      <xsl:element name="w:tcBorders">
+        <xsl:for-each select="'top','left','bottom','right'">
+          <xsl:variable name="outer-border" select="
+            (. = 'top' and $pos[2] eq 1) or
+            (. = 'left' and $pos[1] eq 1) or
+            (. = 'bottom' and $pos[2] eq $pos[4]) or
+            (. = 'right' and $pos[1] eq $pos[3])" as="xs:boolean"/>
+          <xsl:variable name="tblBorder-by-style" as="element()?">
+            <xsl:variable name="borders"
+              select="$tblsty/w:tblPr/w:tblBorders, $tblsty/w:tcPr/w:tcBorders"/>
+            <xsl:element name="w:{.}">
+              <xsl:choose>
+                <xsl:when test="$outer-border">
+                  <xsl:sequence
+                    select="($borders/w:*[local-name() = current()])[last()]/@*"
+                  />
+                </xsl:when>
+                <!-- inner tcBorder -->
+                <xsl:otherwise>
+                  <xsl:sequence
+                    select="($borders/w:insideH[current() = ('top', 'bottom')], $borders/w:insideV[current() = ('left', 'right')])[1]/@*"
+                  />
+                </xsl:otherwise>
+              </xsl:choose>
+            </xsl:element>
+          </xsl:variable>
+          <xsl:variable name="ancestors" as="element()*">
+            <xsl:variable name="resolve-inside" as="element()*">
+              <xsl:choose>
+                <xsl:when test="$outer-border">
+                  <xsl:sequence select="$self/../../w:tblPrEx/w:tblBorders, $self/../../../w:tblPr/w:tblBorders"/>
+                </xsl:when>
+                <!-- inner tcBorder -->
+                <xsl:otherwise>
+                  <xsl:element name="w:tblBorders">
+                    <xsl:element name="w:{.}">
+                      <xsl:sequence
+                        select="(($self/../../w:tblPrEx/w:tblBorders, $self/../../../w:tblPr/w:tblBorders)/(w:insideH[current() = ('top', 'bottom')], w:insideV[current() = ('left', 'right')]))[1]/@*"
+                      />
+                    </xsl:element>
+                  </xsl:element>
+                </xsl:otherwise>
+              </xsl:choose>
+            </xsl:variable>
+            <xsl:sequence select="$resolve-inside[.//@*], $tblsty/w:tcPr/w:tcBorders"/>
+          </xsl:variable>
+          <xsl:variable name="adhoc-border"
+            select="(
+              $self/w:tcBorders/w:*[local-name() = current()],
+              $ancestors/w:*[local-name() = current()]
+            )[1]"
+            as="element()?"
+          />
+          <xsl:variable name="border">
+            <xsl:choose>
+              <xsl:when test="exists($adhoc-border)">
+                <xsl:sequence select="$adhoc-border"/>
+              </xsl:when>
+              <xsl:when test="exists($tblBorder-by-style/@*)">
+                <xsl:sequence select="$tblBorder-by-style"/>
+              </xsl:when>
+              <xsl:otherwise>
+                <xsl:element name="w:{.}">
+                  <xsl:attribute name="w:val" select="'nil'"/>
+                </xsl:element>
+              </xsl:otherwise>
+            </xsl:choose>
+          </xsl:variable>
+          <xsl:apply-templates select="$border" mode="#current"/>
+        </xsl:for-each>
+      </xsl:element>
+    </xsl:copy>
+  </xsl:template>
+  
+  <xsl:template match="w:tc/w:p/w:r" mode="docx2hub:resolve-tblBorders">
+    <xsl:param name="tblsty" tunnel="yes" as="element()*"/>
+    <xsl:variable name="self" select="."/>
+    <xsl:copy>
+      <xsl:apply-templates select="@*" mode="#current"/>
+      <xsl:variable name="consolidated-props" as="element()?">
+        <xsl:variable name="para-style" select="//w:style[@w:styleId = current()/../w:pPr/w:pStyle/@w:val]/w:rPr"
+          as="element()*"/>
+        <xsl:variable name="run-style" select="//w:style[@w:styleId = current()/w:rPr/w:rStyle/@w:val]/w:rPr"
+          as="element()*"/>
+        <!-- all toggle properties according to §17.7.3: 
+          'b', 'bCs', 'caps', 'emboss', 'i', 'iCs', 'imprint', 'outline', 'shadow', 'smallCaps', 'strike', 'vanish' -->
+        <xsl:variable name="style-toggles" as="element()*">
+          <xsl:variable name="table-toggles">
+            <xsl:for-each-group select="$tblsty//(w:b, w:bCs, w:caps, w:emboss, w:i, w:iCs, w:imprint, w:outline, w:shadow, w:smallCaps, w:strike, w:vanish)" group-by="name()">
+              <xsl:sequence select="current-group()[last()]"/>
+            </xsl:for-each-group>
+          </xsl:variable>
+          <xsl:sequence select="($table-toggles, $para-style, $run-style)//(w:b, w:bCs, w:caps, w:emboss, w:i, w:iCs, w:imprint, w:outline, w:shadow, w:smallCaps, w:strike, w:vanish)"/>
+        </xsl:variable>
+        <xsl:if test="exists((w:rPr, $style-toggles))">
+          <xsl:element name="w:rPr">
+            <xsl:apply-templates select="w:rPr/node()"/>
+            <xsl:for-each-group select="$style-toggles" group-by="name()">
+              <xsl:variable name="name" select="current-group()[1]/name()"/>
+              <xsl:variable name="toggle-prop"
+                select="count(($style-toggles[name() = $name][docx2hub:is-toggled(.)]))"
+                as="xs:decimal"/>
+              <xsl:if test="not($self/w:rPr/*[name() = $name]) and $toggle-prop gt 0">
+                <xsl:element name="{$name}">
+                  <xsl:attribute name="w:val"
+                    select="($toggle-prop mod 2)[1]"
+                  />
+                </xsl:element>
+              </xsl:if>
+            </xsl:for-each-group>
+          </xsl:element>
+        </xsl:if>
+      </xsl:variable>
+      <xsl:apply-templates select="$consolidated-props, node() except w:rPr"/>
+    </xsl:copy>
+  </xsl:template>
+  
+  <xsl:function name="docx2hub:is-toggled" as="xs:boolean">
+    <xsl:param name="prop" as="element()"/>
+    <xsl:sequence select="empty($prop/@w:val) or $prop/@w:val = ('1', 'true')"/>
+  </xsl:function>
+  
+</xsl:stylesheet>

--- a/xsl/modules/prop-mapping/propmap.xsl
+++ b/xsl/modules/prop-mapping/propmap.xsl
@@ -191,7 +191,7 @@
           <!-- postprocess it; should be margin-right if the table is rtl (§ 17.4.51) --> 
         </prop> 
         <prop name="w:tblLayout" type="passthru"/>
-        <prop name="w:tblLook" />
+        <prop name="w:tblLook" type="passthru"/>
         <prop name="w:tblPrEx" type="passthru"/>
         <prop name="w:tblStyle" type="docx-parastyle"/>
         <prop name="w:tblW" type="passthru" />

--- a/xsl/wml2dbk.xsl
+++ b/xsl/wml2dbk.xsl
@@ -422,7 +422,7 @@
   </xsl:template>
 
   <xsl:template match="css:rule/w:tblPr" mode="wml-to-dbk">
-    <xsl:apply-templates select="@*" mode="#current"/>
+    <xsl:apply-templates select="@*[not(some $pa in ../@*/name() satisfies $pa = name())]" mode="#current"/>
   </xsl:template>
 
   <xsl:template match="dbk:* | css:*" mode="wml-to-dbk" priority="-0.1">
@@ -444,27 +444,6 @@
       </xsl:if>
       <xsl:apply-templates select="@*, w:tblPr, *[not(self::w:tblPr)], $content" mode="#current" />
     </xsl:copy>   
-  </xsl:template>
-  
-  <xsl:template match="css:rule[w:tblPr[@*[contains(local-name(), 'inside')]]]" mode="wml-to-dbk">
-    <xsl:copy>
-      <xsl:attribute name="layout-type" select="'cell'"/>
-      <xsl:attribute name="name" select="docx2hub:linked-cell-style-name(@name)"/>
-      <xsl:apply-templates select="w:tblPr/@*[contains(local-name(), 'inside')]" mode="#current">
-        <xsl:with-param name="is-first-cell" select="false()" tunnel="yes"/>
-        <xsl:with-param name="is-last-cell" select="false()" tunnel="yes"/>
-        <xsl:with-param name="is-first-row-in-group" select="false()" tunnel="yes"/>
-        <xsl:with-param name="is-last-row-in-group" select="false()" tunnel="yes"/>
-      </xsl:apply-templates>
-    </xsl:copy>
-    <!-- Cell style will be generated before processing the table style. Reason: table border properties
-      will have CSS-precedence over cell border properties. We just need to make sure that a table with 
-      no outer borders will explicitly override the cell style borders if they are present. --> 
-    <xsl:next-match>
-      <xsl:with-param name="content" as="element(dbk:linked-style)">
-        <linked-style xmlns="http://docbook.org/ns/docbook" layout-type="cell" name="{docx2hub:linked-cell-style-name(@name)}"/>
-      </xsl:with-param>
-    </xsl:next-match>
   </xsl:template>
 
   <xsl:template match="@srcpath" mode="wml-to-dbk">


### PR DESCRIPTION
These changes does the following preprocessing:
* calculate table-borders and serialize them on each tcBorder
* take prop-inheritance by table-style into account
* account for settings of first/last row/col (no banding yet, but would be extendable)
* inside tables, calculate toggle-properties (like bold, italic) set by style (table/character/paragraph) and serialize them on runs

Problem is this difference:
in Word, cell-borders override table-borders.
in CSS, the wider border overrides the thinner one, origin (cell/table) is ignored.
To express the Word-border in CSS, it has to be calculated.

flaws:
* no css-rules for table-cells, because its hard to get them through all prop-mappings
* char/para style is not calculated outside of tables, because the style-squashing breaks list-inheritance somehow